### PR TITLE
Implement useHistory and useMatch

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,6 +79,14 @@ export function useRouter() {
   return useContext(RouterContext);
 }
 
+export function useMatch() {
+  return useContext(RouterContext)[0];
+}
+
+export function useHistory() {
+  return useContext(RouterContext)[1];
+}
+
 export function Route<T>(props: T) {
   const [router, actions] = useRouter()!,
     childRouter = mergeProps(router, { level: router.level + 1 }),


### PR DESCRIPTION
This adds exports `useHistory` and `useMatch`. It's annoying to have to discard one or the other of the router objects when one needs only one of the two.

This is a semver minor change.