### PR TITLE
Improve route matching strategy

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -3,10 +3,10 @@ import { createMemo, createRoot, mergeProps, on, Show, splitProps } from "solid-
 import { isServer } from "solid-js/web";
 import { pathIntegration, staticIntegration } from "./integration";
 import {
+  createBranches,
   createRouteContext,
-  createRouteMatches,
   createRouterContext,
-  createRoutes,
+  getRouteMatches,
   RouteContextObj,
   RouterContextObj,
   useHref,
@@ -62,10 +62,10 @@ export const Routes = (props: RoutesProps) => {
   const parentRoute = useRoute();
 
   const basePath = useResolvedPath(() => props.base || "");
-  const routes = createMemo(() =>
-    createRoutes(props.children as RouteDefinition | RouteDefinition[], basePath() || "", Outlet)
+  const branches = createMemo(() =>
+    createBranches(props.children as RouteDefinition | RouteDefinition[], basePath() || "", Outlet)
   );
-  const matches = createMemo(() => createRouteMatches(routes(), router.location.pathname));
+  const matches = createMemo(() => getRouteMatches(branches(), router.location.pathname));
 
   if (router.out) {
     router.out.matches.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type RouteDataFunc = (args: {
 export type RouteDefinition = {
   path: string;
   data?: RouteDataFunc;
-  children?: RouteDefinition[];
+  children?: RouteDefinition | RouteDefinition[];
 } & (
   | {
       element?: never;
@@ -64,7 +64,6 @@ export type RouteDefinition = {
 );
 
 export interface PathMatch {
-  score: number;
   params: Params;
   path: string;
 }
@@ -83,11 +82,16 @@ export interface OutputMatch {
 export interface Route {
   originalPath: string;
   pattern: string;
-  children?: Route[];
   element: () => JSX.Element;
   preload?: () => void;
   data?: RouteDataFunc;
-  matcher: (location: string) => PathMatch | null;
+  matcher: (location: string) => PathMatch | null
+}
+
+export interface Branch {
+  routes: Route[];
+  score: number;
+  matcher: (location: string) => RouteMatch[] | null;
 }
 
 export interface RouteContext {

--- a/test/route.spec.ts
+++ b/test/route.spec.ts
@@ -1,10 +1,460 @@
-import { createRoot, createSignal } from "solid-js";
-import { createRouteContext } from "../src/routing";
-import { RouteMatch } from "../src/types";
-import { createCounter } from "./helpers";
+import { createBranch, createBranches, createRoute } from "../src/routing";
 
-describe("RouteState should", () => {
-  test(`be tested`, () => {
-    expect(true);
+describe("createRoute should", () => {
+  test(`return an object containing the originalPath`, () => {
+    const routeDef = {
+      path: "foo"
+    };
+    const route = createRoute(routeDef);
+    expect(route.originalPath).toBe(routeDef.path);
+  });
+
+  describe(`include pattern which should`, () => {
+    test(`join the base`, () => {
+      const routeDef = {
+        path: "bar"
+      };
+      const route = createRoute(routeDef, '/foo');
+      expect(route.pattern).toBe('/foo/bar');
+    });
+
+    test(`strip /* from the base`, () => {
+      const routeDef = {
+        path: "bar"
+      };
+      const route = createRoute(routeDef, '/foo/*');
+      expect(route.pattern).toBe('/foo/bar');
+    });
+
+    test(`strip /* when the route has children`, () => {
+      const routeDef = {
+        path: "foo/*",
+        children: {
+          path: 'bar'
+        }
+      };
+      const route = createRoute(routeDef);
+      expect(route.pattern).toBe('/foo');
+    });
+  });
+
+  describe(`include matcher function which should`, () => {
+    test(`extract any path parameters`, () => {
+      const routeDef = {
+        path: "foo/:id/bar/:name"
+      };
+      const route = createRoute(routeDef);
+      const { params } = route.matcher('/foo/123/bar/solid')!;
+      expect(params).toEqual({
+        id: '123',
+        name: 'solid'
+      });
+    });
+
+    test(`provide the matched path`, () => {
+      const routeDef = {
+        path: "foo/:id/bar/:name"
+      };
+      const route = createRoute(routeDef);
+      const { path } = route.matcher('/foo/123/bar/solid')!;
+      expect(path).toBe('/foo/123/bar/solid')
+    });
+
+    test(`allow partial match for routes with children`, () => {
+      const routeDef = {
+        path: "foo/:id",
+        children: {
+          path: 'bar/:name'
+        }
+      };
+      const route = createRoute(routeDef);
+      const match = route.matcher('/foo/123/bar/solid');
+      expect(match).not.toBeNull();
+      expect(match!.path).toBe('/foo/123')
+      expect(match!.params).toEqual({
+        id: '123'
+      });
+    });
+
+    test(`allow partial match for routes ending in /*`, () => {
+      const routeDef = {
+        path: "foo/:id/*"
+      };
+      const route = createRoute(routeDef);
+      const match = route.matcher('/foo/123/bar/solid');
+      expect(match).not.toBeNull();
+      expect(match!.path).toBe('/foo/123')
+      expect(match!.params).toEqual({
+        id: '123'
+      });
+    });
+
+    test(`capture remaining location when ending in named splat`, () => {
+      const routeDef = {
+        path: "foo/:id/*all"
+      };
+      const route = createRoute(routeDef);
+      const match = route.matcher('/foo/123/bar/solid');
+      expect(match).not.toBeNull();
+      expect(match!.path).toBe('/foo/123')
+      expect(match!.params).toEqual({
+        id: '123',
+        all: 'bar/solid'
+      });
+    });
+
+    test(`match case insensitive`, () => {
+      const routeDef = {
+        path: "foo/bar/baz"
+      };
+      const route = createRoute(routeDef);
+      const match = route.matcher('/fOo/BAR/bAZ');
+      expect(match).not.toBeNull();
+    });
+
+    test(`preserve param name casing`, () => {
+      const routeDef = {
+        path: "foo/:sUpEr/*aLL"
+      };
+      const route = createRoute(routeDef);
+      const { params } = route.matcher('/foo/123/bar/solid')!;
+      expect(params).toEqual({
+        sUpEr: '123',
+        aLL: 'bar/solid'
+      });
+    });
+
+    test(`preserve param value casing`, () => {
+      const routeDef = {
+        path: "foo/:id/*all"
+      };
+      const route = createRoute(routeDef);
+      const { params } = route.matcher('/foo/someTHING/BaR/sOlId')!;
+      expect(params).toEqual({
+        id: 'someTHING',
+        all: 'BaR/sOlId'
+      });
+    });
+  });
+});
+
+describe("createBranch should", () => {
+  test(`return an object containing the provided routes`, () => {
+    const routes = [
+      createRoute({
+        path: "foo"
+      }),
+      createRoute({
+        path: "foo/bar"
+      })
+    ];
+    const branch = createBranch(routes);
+    expect(branch.routes).toBe(routes);
+  });
+
+  describe(`include a score which should`, () => {
+    test("prioritize segment count", () => {
+      const branch1 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar',
+            children: {
+              path: 'baz'
+            }
+          }
+        }),
+        createRoute({
+          path: "foo/bar",
+          children: {
+            path: 'baz'
+          }
+        }),
+        createRoute({
+          path: "foo/bar/baz"
+        })
+      ]);
+      const branch2 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar'
+          }
+        }),
+        createRoute({
+          path: "foo/bar"
+        })
+      ]);
+      expect(branch1.score).toBeGreaterThan(branch2.score);
+    });
+
+    test("prioritize literal segments", () => {
+      const branch1 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar'
+          }
+        }),
+        createRoute({
+          path: "foo/bar"
+        })
+      ]);
+      const branch2 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: ':id'
+          }
+        }),
+        createRoute({
+          path: "foo/:id"
+        })
+      ]);
+      expect(branch1.score).toBeGreaterThan(branch2.score);
+    });
+
+    test("prioritize order", () => {
+      const branch1 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar'
+          }
+        }),
+        createRoute({
+          path: "foo/bar"
+        })
+      ], 0);
+      const branch2 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar'
+          }
+        }),
+        createRoute({
+          path: "foo/bar"
+        })
+      ], 1);
+      expect(branch1.score).toBeGreaterThan(branch2.score);
+    });
+
+    test("deprioritize catch all /*", () => {
+      const branch1 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar'
+          }
+        }),
+        createRoute({
+          path: "foo/bar"
+        })
+      ]);
+      const branch2 = createBranch([
+        createRoute({
+          path: "foo",
+          children: {
+            path: 'bar/*'
+          }
+        }),
+        createRoute({
+          path: "foo/bar/*"
+        })
+      ]);
+      expect(branch1.score).toBeGreaterThan(branch2.score);
+    });
+
+    describe("include a matcher function which should", () => {
+      test("return each route's match", () => {
+        const branch = createBranch([
+          createRoute({
+            path: "foo/:id",
+            children: {
+              path: 'bar/:name'
+            }
+          }),
+          createRoute({
+            path: "foo/:id/bar/:name"
+          })
+        ]);
+        const location = '/foo/123/bar/solid';
+        const match = branch.matcher(location);
+        expect(match).not.toBeNull();
+
+        const matches = match!.map(({ params, path }) => ({
+          params,
+          path
+        }));
+        const expected = branch.routes.map((route) => ({
+          ...route.matcher(location),
+        }));
+        expect(matches).toEqual(expected)
+      });
+
+      test("short circuit if the final route doesn't match", () => {
+        const branch = createBranch([
+          createRoute({
+            path: "foo/:id",
+            children: {
+              path: 'bar/:name'
+            }
+          }),
+          createRoute({
+            path: "foo/:id/bar/:name"
+          })
+        ]);
+        const spy = jest.spyOn(branch.routes[0], 'matcher')
+        const location = '/foo/123/bar';
+        const match = branch.matcher(location);
+        expect(match).toBeNull();
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});
+
+describe("createBranches should", () => {
+  test(`produce depth-first enumeration of route definitions`, () => {
+    const branches = createBranches({
+      path: "root",
+      children: [
+        {
+          path: "a1",
+          children: [
+            {
+              path: "a2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            },
+            {
+              path: "b2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            },
+            {
+              path: "c2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          path: "b1",
+          children: [
+            {
+              path: "a2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            },
+            {
+              path: "b2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            },
+            {
+              path: "c2",
+              children: [
+                {
+                  path: "a3"
+                },
+                {
+                  path: "b3"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+
+    const branchPaths = branches.map(b => b.routes[b.routes.length - 1].pattern);
+
+    expect(branchPaths).toEqual([
+      "/root/a1/a2/a3",
+      "/root/a1/a2/b3",
+      "/root/a1/b2/a3",
+      "/root/a1/b2/b3",
+      "/root/a1/c2/a3",
+      "/root/a1/c2/b3",
+      "/root/b1/a2/a3",
+      "/root/b1/a2/b3",
+      "/root/b1/b2/a3",
+      "/root/b1/b2/b3",
+      "/root/b1/c2/a3",
+      "/root/b1/c2/b3"
+    ]);
+  });
+
+  test(`order the routes by score descending`, () => {
+    const branches = createBranches({
+      path: "root",
+      children: [
+        {
+          path: "/*",
+        },
+        {
+          path: ":id",
+        },
+        {
+          path: "foo",
+          children: [{
+            path: 'bar'
+          }, {
+            path: 'bar/*'
+          }]
+        },
+        {
+          path: "baz/qux",
+        }
+      ]
+    });
+
+    const branchPaths = branches.map(b => b.routes[b.routes.length - 1].pattern);
+    const scores = branches.map(b => b.score);
+
+    expect(branchPaths).toEqual([
+      "/root/foo/bar",
+      "/root/baz/qux",
+      "/root/foo/bar/*",
+      "/root/:id",
+      "/root/*",
+    ]);
+
+    expect(scores[0]).toBeGreaterThan(scores[1]);
+    expect(scores[1]).toBeGreaterThan(scores[2]);
+    expect(scores[2]).toBeGreaterThan(scores[3]);
+    expect(scores[3]).toBeGreaterThan(scores[4]);
   });
 });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { createPathMatcher, createLocationMatcher, resolvePath } from '../src/utils';
+import { createMatcher, resolvePath } from '../src/utils';
 
 describe('resolvePath should', () => {
   test('normalize the base arg', () => {
@@ -62,10 +62,10 @@ describe('resolvePath should', () => {
   });
 });
 
-describe('createPathMatcher should', () => {
+describe('createMatcher should', () => {
   test('return empty object when location matches simple path', () => {
     const expected = { path: '/foo/bar', params: {}};
-    const matcher = createPathMatcher('/foo/bar');
+    const matcher = createMatcher('/foo/bar');
     const match = matcher('/foo/bar');
     expect(match).not.toBe(null);
     expect(match!.path).toBe(expected.path);
@@ -74,14 +74,14 @@ describe('createPathMatcher should', () => {
 
   test('return null when location does not match', () => {
     const expected = null;
-    const matcher = createPathMatcher('/foo/bar');
+    const matcher = createMatcher('/foo/bar');
     const match = matcher('/foo/baz');
     expect(match).toEqual(expected);
   });
 
   test('return params collection when location matches parameterized path', () => {
     const expected = { path: '/foo/abc-123', params: { id: 'abc-123' }};
-    const matcher = createPathMatcher('/foo/:id');
+    const matcher = createMatcher('/foo/:id');
     const match = matcher('/foo/abc-123');
     expect(match).not.toBe(null);
     expect(match!.path).toBe(expected.path);
@@ -90,7 +90,7 @@ describe('createPathMatcher should', () => {
 
   test('match past end when end when ending in a /*', () => {
     const expected = { path: '/foo/bar', params: {}}
-    const matcher = createPathMatcher('/foo/bar/*');
+    const matcher = createMatcher('/foo/bar/*');
     const match = matcher('/foo/bar/baz');
     expect(match).not.toBe(null);
     expect(match!.path).toBe(expected.path);
@@ -99,14 +99,14 @@ describe('createPathMatcher should', () => {
 
   test('not match past end when not ending in /*', () => {
     const expected = null;
-    const matcher = createPathMatcher('/foo/bar');
+    const matcher = createMatcher('/foo/bar');
     const match = matcher('/foo/bar/baz');
     expect(match).toBe(expected);
   });
 
   test('include remaining unmatched location as param when ending in /*param_name', () => {
     const expected = { path: '/foo/bar', params: { something: 'baz/qux' }}
-    const matcher = createPathMatcher('/foo/bar/*something');
+    const matcher = createMatcher('/foo/bar/*something');
     const match = matcher('/foo/bar/baz/qux');
     expect(match).not.toBe(null);
     expect(match!.path).toBe(expected.path);
@@ -115,26 +115,10 @@ describe('createPathMatcher should', () => {
 
   test('include empty param when ending in /*param_name and exact match', () => {
     const expected = { path: '/foo/bar', params: { something: '' }}
-    const matcher = createPathMatcher('/foo/bar/*something');
+    const matcher = createMatcher('/foo/bar/*something');
     const match = matcher('/foo/bar');
     expect(match).not.toBe(null);
     expect(match!.path).toBe(expected.path);
     expect(match!.params).toEqual(expected.params);
-  });
-});
-
-describe('createLocationMatcher should', () => {
-  test('match past end when end option is false', () => {
-    const expected = true;
-    const matcher = createLocationMatcher('/foo/bar');
-    const match = matcher('/foo/bar/baz');
-    expect(match).toBe(expected);
-  });
-
-  test('not match past end when end option is true', () => {
-    const expected = false;
-    const matcher = createLocationMatcher('/foo/bar', true);
-    const match = matcher('/foo/bar/baz');
-    expect(match).toBe(expected);
   });
 });


### PR DESCRIPTION
Currently routes are matched in isolation and only compared against their siblings to determine a winner. This PR, changes the strategy to build all route branch permutations using a depth-first traversal, rank them and use the first, highest-ranked branch which matches the current location. This change moves the router more in line with React Router 6.

Changes:
- No external API changes
- Routes will now only match if a branch they are part of matches. Currently a non-leaf route could match even if it's children did not. With this change that will only be possible by adding a `/*` route as a child.
- Equivalent paths will depend on traversal order/document order instead of shallowness.
- Fixes #26 - param names and values correctly preserve their case.