### PR TITLE
Replace navigate with navigatorFactory on RouterContext

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface Navigator {
   (to: number): void;
 }
 
+export type NavigatorFactory = () => Navigator;
+
 export interface LocationChange {
   value: string;
   replace?: boolean;
@@ -125,7 +127,7 @@ export interface RouterContext {
   base: RouteContext;
   out?: RouterOutput;
   location: Location;
-  navigate: Navigator;
+  navigatorFactory: NavigatorFactory;
   isRouting: () => boolean;
   renderPath(path: string): string;
 }

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -180,7 +180,8 @@ describe("Router should", () => {
         const signal = createSignal<LocationChange>({
           value: "/"
         });
-        const { location, navigate } = createRouterContext(signal);
+        const { location, navigatorFactory } = createRouterContext(signal);
+        const navigate = navigatorFactory();
 
         expect(location.pathname).toBe("/");
         navigate("/foo/1");
@@ -197,7 +198,8 @@ describe("Router should", () => {
         const signal = createSignal<LocationChange>({
           value: "/foo/bar"
         });
-        const { location, navigate } = createRouterContext(signal);
+        const { location, navigatorFactory } = createRouterContext(signal);
+        const navigate = navigatorFactory();
         const count = createCounter(() => location.pathname);
 
         expect(location.pathname).toBe("/foo/bar");
@@ -211,7 +213,8 @@ describe("Router should", () => {
         const signal = createSignal<LocationChange>({
           value: "/"
         });
-        const { navigate } = createRouterContext(signal);
+        const { navigatorFactory } = createRouterContext(signal);
+        const navigate = navigatorFactory();
         expect(signal[0]().value).toBe("/");
         navigate("/foo/bar");
 
@@ -227,7 +230,8 @@ describe("Router should", () => {
         const signal = createSignal<LocationChange>({
           value: "/"
         });
-        const { navigate } = createRouterContext(signal);
+        const { navigatorFactory } = createRouterContext(signal);
+        const navigate = navigatorFactory();
 
         expect(signal[0]()).toEqual({ value: "/" });
         navigate("/foo/1");
@@ -248,7 +252,8 @@ describe("Router should", () => {
         const signal = createSignal<LocationChange>({
           value: "/"
         });
-        const { navigate } = createRouterContext(signal);
+        const { navigatorFactory } = createRouterContext(signal);
+        const navigate = navigatorFactory();
         function pushAlot() {
           for (let i = 0; i < 101; i++) {
             navigate(`/foo/${i}`);


### PR DESCRIPTION
This PR resolves an issue in using a `navigate` function (returned from `useNavigate`) to navigate to a path relative to the current route context.

For example, in this component:

```tsx
function MyComponent() {
  const navigate = useNavigate();

  function handleCloseButtonClick() {
    if (navigationAllowed()) {
      navigate('some/relative/path');
    }
  }

  ...
}
```

…the relative navigation will fail, because the `navigate` function does not retain the route context of the component instance. The `navigate` function invokes an internal `useRoute` function (in `src/routing.ts`) to get the current route, but the route context provider has already lost the route that was in effect when `MyComponent` was invoked and therefore returns `undefined`. Consequently the router's base route (typically `/`) is used as a fallback for path resolution, which yields an invalid path relative to the router base route, instead of the correct path relative to the component's route.

The `Link` component resolves its path relative to the route context at render time and therefore doesn't suffer the same problems as with a delayed `navigate`, but it may not satisfy all of the use cases possible by calling a `navigate` function directly, such as the conditional navigation example above.

It seems reasonable to expect that `useNavigate` should return a `navigate` function that can be invoked any time later to navigate relative to the original route context of the component from which `useNavigate` was called. Accordingly, this PR replaces the `navigate` function in the router context with a navigator factory, which returns a generated `navigate` function that references the route context currently in effect when the factory is called. This allows relative navigation to work in the above example or anywhere else where `navigate` needs to be called after the component is constructed and rendered.