### PR TITLE
Add a new "hook" useSearchParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,18 +168,12 @@ const params = useParams();
 const [user] = createResource(() => params.id, fetchUser);
 ```
 
-### useLocation
-
-Retrieves reactive `location` object useful for getting things like `pathname` or `query`
-
-```js
-const location = useLocation();
-
-const createMemo(() => parseQuery(location.query));
-```
 ### useNavigate
 
-Retrieves method to do navigation.
+Retrieves method to do navigation. The method accepts a path to navigate to and an optional object with the following options:
+- resolve (*boolean*, default `true`): resolve the path against the current route
+- replace (*boolean*, default `false`): replace the history entry
+- scroll (*boolean*, default `true`): scroll to top after navigation
 
 ```js
 const navigate = useNavigate();
@@ -187,6 +181,31 @@ const navigate = useNavigate();
 if (unauthorized) {
   navigate("/login", { replace: true });
 }
+```
+
+### useLocation
+
+Retrieves reactive `location` object useful for getting things like `pathname`
+
+```js
+const location = useLocation();
+
+const createMemo(() => parseQuery(location.query));
+```
+
+### useSearchParams
+
+Retrieves a tuple containing a reactive object to read the current location's query parameters and a method to update them. The object is a proxy so you must access properties to subscribe to reactive updates. Note values will be strings and property names will retain their casing.
+
+The setter method accepts an object whos entries will be merged into the current query string. Values `''`, `undefined` and `null` will remove the key from the resulting query string. Updates will behave just like a navigation and the setter accepts the same optional second parameter as `navigate` and auto-scrolling is disabled by default.
+
+```js
+const [searchParams, setSearchParams] = useSearchParams();
+
+return <div>
+  <span>Page: {searchParams.page}</span>
+  <button onClick={() => setSeachParams({ page: searchParams.page + 1})}>Next Page</button>
+</div>
 ```
 
 ### useIsRouting

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,10 +8,10 @@ export {
   useMatch,
   useNavigate,
   useParams,
-  useQuery,
-  useResolvedPath
+  useResolvedPath,
+  useSearchParams
 } from "./routing";
-export { mergeQueryString as _mergeQueryString } from "./utils";
+export { mergeSearchString as _mergeSearchString } from "./utils";
 export type {
   Location,
   LocationChange,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,10 @@ export {
   useMatch,
   useNavigate,
   useParams,
+  useQuery,
   useResolvedPath
 } from "./routing";
+export { mergeQueryString as _mergeQueryString } from "./utils";
 export type {
   Location,
   LocationChange,
@@ -24,5 +26,6 @@ export type {
   RouteDefinition,
   RouterIntegration,
   RouterOutput,
-  RouterUtils
+  RouterUtils,
+  SetParams
 } from "./types";

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -32,13 +32,13 @@ import type {
 } from "./types";
 import {
   createMemoObject,
-  extractQuery,
+  extractSearchParams,
   invariant,
   resolvePath,
   createMatcher,
   joinPaths,
   scoreRoute,
-  mergeQueryString
+  mergeSearchString
 } from "./utils";
 
 const MAX_REDIRECTS = 100;
@@ -80,14 +80,17 @@ export const useMatch = (path: () => string) => {
 
 export const useParams = <T extends Params>() => useRoute().params as T;
 
-export const useQuery = <T extends Params>(): [T, (params: SetParams) => void] => {
+export const useSearchParams = <T extends Params>(): [
+  T,
+  (params: SetParams, options?: Partial<NavigateOptions>) => void
+] => {
   const location = useLocation();
   const navigate = useNavigate();
-  const setQuery = (params: SetParams) => {
-    const query = mergeQueryString(location.search, params);
-    navigate(query ? `?${query}` : "", { scroll: false });
+  const setSearchParams = (params: SetParams, options?: Partial<NavigateOptions>) => {
+    const searchString = mergeSearchString(location.search, params);
+    navigate(searchString ? `?${searchString}` : "", { scroll: false, ...options, resolve: true });
   };
-  return [location.query as T, setQuery];
+  return [location.query as T, setSearchParams];
 };
 
 export const useData = <T>(delta: number = 0) => {
@@ -232,7 +235,7 @@ export function createLocation(path: () => string): Location {
     get key() {
       return key();
     },
-    query: createMemoObject(on(search, () => extractQuery(url())))
+    query: createMemoObject(on(search, () => extractSearchParams(url())))
   };
 }
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -27,7 +27,8 @@ import type {
   RouteMatch,
   RouterContext,
   RouterIntegration,
-  RouterOutput
+  RouterOutput,
+  SetParams
 } from "./types";
 import {
   createMemoObject,
@@ -36,7 +37,8 @@ import {
   resolvePath,
   createMatcher,
   joinPaths,
-  scoreRoute
+  scoreRoute,
+  mergeQueryString
 } from "./utils";
 
 const MAX_REDIRECTS = 100;
@@ -77,6 +79,16 @@ export const useMatch = (path: () => string) => {
 };
 
 export const useParams = <T extends Params>() => useRoute().params as T;
+
+export const useQuery = <T extends Params>(): [T, (params: SetParams) => void] => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const setQuery = (params: SetParams) => {
+    const query = mergeQueryString(location.search, params);
+    navigate(query ? `?${query}` : "");
+  };
+  return [location.query as T, setQuery];
+};
 
 export const useData = <T>(delta: number = 0) => {
   let current = useRoute();
@@ -307,9 +319,9 @@ export function createRouterContext(
         } else {
           const len = referrers.push({ value: current, replace, scroll });
           start(() => setReference(resolvedTo), () => {
-            if (referrers.length === len) {
-              navigateEnd(resolvedTo);
-            }
+              if (referrers.length === len) {
+                navigateEnd(resolvedTo);
+              }
           });
         }
       }

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -318,11 +318,14 @@ export function createRouterContext(
           setSource({ value: resolvedTo, replace, scroll });
         } else {
           const len = referrers.push({ value: current, replace, scroll });
-          start(() => setReference(resolvedTo), () => {
+          start(
+            () => setReference(resolvedTo),
+            () => {
               if (referrers.length === len) {
                 navigateEnd(resolvedTo);
               }
-          });
+            }
+          );
         }
       }
     });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -85,7 +85,7 @@ export const useQuery = <T extends Params>(): [T, (params: SetParams) => void] =
   const navigate = useNavigate();
   const setQuery = (params: SetParams) => {
     const query = mergeQueryString(location.search, params);
-    navigate(query ? `?${query}` : "");
+    navigate(query ? `?${query}` : "", { scroll: false });
   };
   return [location.query as T, setQuery];
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,8 @@ import { Component, JSX } from "solid-js";
 
 export type Params = Record<string, string>;
 
+export type SetParams = Record<string, string | number | boolean | null | undefined>;
+
 export type LocationState = string | null;
 
 export interface Path {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ const trimPathRegex = /^\/+|\/+$|\s+/;
 
 function normalize(path: string) {
   const s = path.replace(trimPathRegex, "");
-  return s ? s.startsWith('?') ? s : "/" + s : "";
+  return s ? (s.startsWith("?") ? s : "/" + s) : "";
 }
 
 export function resolvePath(base: string, path: string, from?: string): string | undefined {
@@ -51,7 +51,7 @@ export function extractQuery(url: URL): Params {
 }
 
 export function createMatcher(path: string, partial?: boolean) {
-  const [pattern, splat] = path.split("/*", 2)
+  const [pattern, splat] = path.split("/*", 2);
   const segments = pattern.split("/").filter(Boolean);
   const len = segments.length;
 
@@ -73,7 +73,7 @@ export function createMatcher(path: string, partial?: boolean) {
 
       if (segment[0] === ":") {
         match.params[segment.slice(1)] = locSegment;
-      } else if (segment.localeCompare(locSegment, undefined, { sensitivity: 'base' }) !== 0) {
+      } else if (segment.localeCompare(locSegment, undefined, { sensitivity: "base" }) !== 0) {
         return null;
       }
       match.path += `/${locSegment}`;
@@ -84,7 +84,7 @@ export function createMatcher(path: string, partial?: boolean) {
     }
 
     return match;
-  }
+  };
 }
 
 export function scoreRoute(route: Route): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,12 +42,12 @@ export function joinPaths(from: string, to: string): string {
   return to ? `${from.replace(/[/*]+$/, "")}/${to.replace(/^\/+/, "")}` : from;
 }
 
-export function extractQuery(url: URL): Params {
-  const query: Params = {};
+export function extractSearchParams(url: URL): Params {
+  const params: Params = {};
   url.searchParams.forEach((value, key) => {
-    query[key] = value;
+    params[key] = value;
   });
-  return query;
+  return params;
 }
 
 export function createMatcher(path: string, partial?: boolean) {
@@ -116,8 +116,8 @@ export function createMemoObject<T extends object>(fn: () => T): T {
   ) as T;
 }
 
-export function mergeQueryString(queryString: string, params: SetParams) {
-  const merged = new URLSearchParams(queryString);
+export function mergeSearchString(search: string, params: SetParams) {
+  const merged = new URLSearchParams(search);
   Object.entries(params).forEach(([key, value]) => {
     if (value == null || value === "") {
       merged.delete(key);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { createMemo, getOwner, runWithOwner } from "solid-js";
-import type { Params, PathMatch, Route } from "./types";
+import type { Params, PathMatch, Route, SetParams } from "./types";
 
 const hasSchemeRegex = /^(?:[a-z0-9]+:)?\/\//i;
 const trimPathRegex = /^\/+|\/+$|\s+/;
@@ -114,4 +114,16 @@ export function createMemoObject<T extends object>(fn: () => T): T {
       }
     }
   ) as T;
+}
+
+export function mergeQueryString(queryString: string, params: SetParams) {
+  const merged = new URLSearchParams(queryString);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value == null || value === "") {
+      merged.delete(key);
+    } else {
+      merged.set(key, String(value));
+    }
+  });
+  return merged.toString();
 }


### PR DESCRIPTION
This PR adds a new "hook" `useSearchParams` which makes getting and updating query parameters easier. `useSearchParams` returns a getter/setter tuple.

- The getter is the same object `useLocation().query` so it is a reactive proxy and not a function.
- The setter function expects a POJO containing the query parameters you want to update.
  - Updates are merged so to remove an existing query parameter, you need to set it to `''`, `udefined`, or `null`.
  - Updates use a navigation and have `scroll: false` applied by default

This PR also exports a utility function `_mergeSearchString` (underscore prefix to note instability) which powers the setter described above and can be useful for creating query strings for Links. In the future this will probably be replaced with a better API for links/navigations which allow defining hrefs as an object where you can specify query params to merge.