### PR TITLE
Allow to pass some state between routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Retrieves method to do navigation. The method accepts a path to navigate to and 
 - resolve (*boolean*, default `true`): resolve the path against the current route
 - replace (*boolean*, default `false`): replace the history entry
 - scroll (*boolean*, default `true`): scroll to top after navigation
+- state (*any*, default `undefined`): pass custom state to `location.state`
 
 ```js
 const navigate = useNavigate();

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -248,13 +248,14 @@ export function NavLink(props: NavLinkProps) {
 
 export interface NavigateProps {
   href: ((args: { navigate: Navigator; location: Location }) => string) | string;
+  state?: unknown
 }
 
 export function Navigate(props: NavigateProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { href } = props;
+  const { href, state } = props;
   const path = typeof href === "function" ? href({ navigate, location }) : href;
-  navigate(path, { replace: true });
+  navigate(path, { replace: true, state });
   return null;
 }

--- a/src/components.tsx
+++ b/src/components.tsx
@@ -165,10 +165,11 @@ interface LinkBaseProps extends JSX.AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string | undefined;
   replace?: boolean;
   noScroll?: boolean;
+  state?: unknown;
 }
 
 function LinkBase(props: LinkBaseProps) {
-  const [, rest] = splitProps(props, ["children", "to", "href", "onClick"]);
+  const [, rest] = splitProps(props, ["children", "to", "href", "state", "onClick"]);
   const navigate = useNavigate();
   const href = useHref(() => props.to);
 
@@ -187,7 +188,12 @@ function LinkBase(props: LinkBaseProps) {
       !(evt.metaKey || evt.altKey || evt.ctrlKey || evt.shiftKey)
     ) {
       evt.preventDefault();
-      navigate(to, { resolve: false, replace: props.replace || false, scroll: !props.noScroll });
+      navigate(to, {
+        resolve: false,
+        replace: props.replace || false,
+        scroll: !props.noScroll,
+        state: props.state
+      });
     }
   };
 
@@ -202,6 +208,7 @@ export interface LinkProps extends JSX.AnchorHTMLAttributes<HTMLAnchorElement> {
   href: string;
   replace?: boolean;
   noScroll?: boolean;
+  state?: unknown;
 }
 
 export function Link(props: LinkProps) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,7 +16,6 @@ export type {
   Location,
   LocationChange,
   LocationChangeSignal,
-  LocationState,
   NavigateOptions,
   Navigator,
   OutputMatch,

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -69,11 +69,11 @@ export function staticIntegration(obj: LocationChange): RouterIntegration {
 export function pathIntegration() {
   return createIntegration(
     () => window.location.pathname + window.location.search + window.location.hash,
-    ({ value, replace, scroll }) => {
+    ({ value, replace, scroll, state }) => {
       if (replace) {
-        window.history.replaceState(null, "", value);
+        window.history.replaceState(state, "", value);
       } else {
-        window.history.pushState(null, "", value);
+        window.history.pushState(state, "", value);
       }
       if (scroll) {
         window.scrollTo(0, 0);
@@ -86,7 +86,7 @@ export function pathIntegration() {
 export function hashIntegration() {
   return createIntegration(
     () => window.location.hash.slice(1),
-    ({ value, scroll}) => {
+    ({ value, scroll }) => {
       window.location.hash = value;
       if (scroll) {
         window.scrollTo(0, 0);

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -328,7 +328,10 @@ export function createRouterContext(
             },
             () => {
               if (referrers.length === len) {
-                navigateEnd(resolvedTo);
+                navigateEnd({
+                  value: resolvedTo,
+                  state
+                });
               }
             }
           );
@@ -344,15 +347,14 @@ export function createRouterContext(
       navigateFromRoute(route!, to, options);
   }
 
-  function navigateEnd(next: string) {
+  function navigateEnd(next: LocationChange) {
     const first = referrers[0];
     if (first) {
-      if (next !== first.value) {
+      if (next.value !== first.value) {
         setSource({
-          value: next,
+          ...next,
           replace: first.replace,
-          scroll: first.scroll,
-          state: first.state
+          scroll: first.scroll
         });
       }
       referrers.length = 0;

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -229,7 +229,7 @@ export function createLocation(path: Accessor<string>, state: Accessor<any>): Lo
       return hash();
     },
     get state() {
-      return state() || null;
+      return state();
     },
     get key() {
       return key();
@@ -323,7 +323,6 @@ export function createRouterContext(
           const len = referrers.push({ value: current, replace, scroll, state });
           start(
             () => {
-              // TODO: not sure about batch()
               setReference(resolvedTo);
               setState(state);
             },
@@ -364,7 +363,6 @@ export function createRouterContext(
     const next = source().value;
     if (next !== untrack(reference)) {
       start(() => {
-        // TODO same
         setReference(next);
         setState(state);
       });

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -360,10 +360,10 @@ export function createRouterContext(
   }
 
   createRenderEffect(() => {
-    const next = source().value;
-    if (next !== untrack(reference)) {
+    const { value, state } = source();
+    if (value !== untrack(reference)) {
       start(() => {
-        setReference(next);
+        setReference(value);
         setState(state);
       });
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,25 +4,23 @@ export type Params = Record<string, string>;
 
 export type SetParams = Record<string, string | number | boolean | null | undefined>;
 
-export type LocationState = string | null;
-
 export interface Path {
   pathname: string;
   search: string;
   hash: string;
 }
 
-export interface Location<S extends LocationState = LocationState> extends Path {
+export interface Location<S = unknown> extends Path {
   query: Params;
-  state: S;
+  state: Readonly<Partial<S>> | null;
   key: string;
 }
 
-export interface NavigateOptions {
+export interface NavigateOptions<S = unknown> {
   resolve: boolean;
   replace: boolean;
   scroll: boolean;
-  state: LocationState;
+  state: S;
 }
 
 export interface Navigator {
@@ -32,10 +30,11 @@ export interface Navigator {
 
 export type NavigatorFactory = (route?: RouteContext) => Navigator;
 
-export interface LocationChange {
+export interface LocationChange<S = unknown> {
   value: string;
   replace?: boolean;
   scroll?: boolean;
+  state?: S;
 }
 
 export type LocationChangeSignal = [() => LocationChange, (next: LocationChange) => void];

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -72,7 +72,8 @@ describe("Router should", () => {
           expect(count()).toBe(0);
         }));
     });
-    describe(`contain propery 'queryString' which should`, () => {
+
+    describe(`contain property 'queryString' which should`, () => {
       test(`be reactive to the queryString part of the integration signal`, () =>
         createAsyncRoot(resolve => {
           const expected = "fizz=buzz";
@@ -226,6 +227,23 @@ describe("Router should", () => {
           resolve();
         });
       }));
+
+    test(`pass state to location`, () => createAsyncRoot(resolve => {
+      const state = { foo: 'bar' };
+      const signal = createSignal<LocationChange>({ value: "/" });
+
+      const { location, navigatorFactory } = createRouterContext(signal);
+      const navigate = navigatorFactory();
+
+      expect(location.state).toBeUndefined();
+      navigate("/foo", { state });
+
+      waitFor(() => signal[0]().value === "/foo").then(n => {
+        expect(n).toBe(1);
+        expect(location.state).toEqual(state);
+        resolve();
+      });
+    }));
 
     test(`be able to be called many times before it updates the integrationSignal`, () =>
       createAsyncRoot(resolve => {


### PR DESCRIPTION
Hi,

For context https://github.com/solidjs/solid-app-router/issues/51

This is just a draft, please, review. If it's fine, I'll try to create some tests and update readme.

The main idea is able to pass some state between routes. For example:

```jsx
// route a
navigate('/b', { state: { value: 1 } });

// route b
const location = useLocation<{ value: number }>();
const valueFromPrevRoute = location.state?.value; // number | undefined
```