### PR TITLE
Negative numbers in useData for counting from top

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ return <div classList={{ "grey-out": isRouting() }}>
 
 ### useData
 
-Retrieves the return value from the data function. You can access parent data by passing a number to indicate ancestor. No argument is the route's own data, `1` is the immediate parent, `2` is the parent's parent, and so on.
+Retrieves the return value from the data function. You can access parent data by passing a number to indicate ancestor. No argument (or `0`) is the route's own data, `1` is the immediate parent, `2` is the parent's parent, and so on. Alternatively, `-1` is the top-level route's data, `-2` is the immediate child, etc.
 
 ```js
 const user = useData();

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -95,8 +95,23 @@ export const useSearchParams = <T extends Params>(): [
 
 export const useData = <T>(delta: number = 0) => {
   let current = useRoute();
-  let n = delta;
-  while (n-- > 0) {
+  let n: number;
+  if (delta >= 0) {
+    // Nonnegative numbers count number of levels up from route
+    n = delta;
+  } else if (delta < 0) {
+    // Negative numbers count backwards, down from root route
+    let count = 1, ancestor = current;
+    while (ancestor.parent) {
+      ancestor = ancestor.parent;
+      count++;
+    }
+    n = count + delta;
+    if (n < 0) {
+      throw new RangeError(`Route descendant ${delta} is out of bounds`);
+    }
+  }
+  while (n!-- > 0) {
     if (!current.parent) {
       throw new RangeError(`Route ancestor ${delta} is out of bounds`);
     }


### PR DESCRIPTION
As [discussed in #website](https://discord.com/channels/722131463138705510/722167449251741798/929055041766174770), this adds functionality to `useData` so that negative numbers count from the root instead of the child.

I've tested this via `npm link` in `solid-website`, but it'd be great to add local tests for `useData` (there are currently none). Would someone else be willing to do that, here or in another PR?