### PR TITLE
Add inactiveClass to NavLinks component

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -219,12 +219,13 @@ export function Link(props: LinkProps) {
 }
 
 export interface NavLinkProps extends LinkProps {
+  inactiveClass?: string;
   activeClass?: string;
   end?: boolean;
 }
 
 export function NavLink(props: NavLinkProps) {
-  props = mergeProps({ activeClass: "active" }, props);
+  props = mergeProps({ inactiveClass: "inactive", activeClass: "active" }, props);
   const [, rest] = splitProps(props, ["activeClass", "end"]);
   const location = useLocation();
   const to = useResolvedPath(() => props.href);
@@ -242,7 +243,7 @@ export function NavLink(props: NavLinkProps) {
     <LinkBase
       {...rest}
       to={to()}
-      classList={{ [props.activeClass!]: isActive() }}
+      classList={{ [props.inactiveClass!]: !isActive(), [props.activeClass!]: isActive() }}
       aria-current={isActive() ? "page" : undefined}
     />
   );


### PR DESCRIPTION
With windi/tailwind it's easier to have inactive classes than working against specificity. Added "inactive" default for symantics.

This wont do anything:
```
<NavLink href="/some-page" class="no-underline" activeClass="underline"
    Some Page
</NavLink>
```


So we introduce this:
```
<NavLink href="/some-page" inactiveClass="no-underline" activeClass="underline"
    Some Page
</NavLink>
```