### PR TITLE
Add Note To `useNavigate` About State Serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Retrieves method to do navigation. The method accepts a path to navigate to and 
 - scroll (_boolean_, default `true`): scroll to top after navigation
 - state (_any_, default `undefined`): pass custom state to `location.state`
 
+__Note:__ The state is serialized using the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) which does not support all object types.
+
 ```js
 const navigate = useNavigate();
 


### PR DESCRIPTION
The documentation / type definition for [`useNavigate`](https://github.com/solidjs/solid-app-router#usenavigate) allows the use of `any` type when specifying the `state` parameter but [not all object types are supported](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#things_that_dont_work_with_structured_clone) since they are serialized using the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).

A note about serialization could help others anticipate [`DataCloneError`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#datacloneerror) exceptions when working with history states. I ran into this issue when attempting to save an `Error` to the state in Firefox (97.0.1/64-bit). MDN notes that Chrome (i.e. Chromium) doesn't have the same issue and that Mozilla is working on it but that's beside the point. 

Here's a demo of what I encountered: https://xls3cm.csb.app/