### PR TITLE
fix(docs): fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Retrieves reactive `location` object useful for getting things like `pathname`
 ```js
 const location = useLocation();
 
-const createMemo(() => parsePath(location.pathname));
+const pathname = createMemo(() => parsePath(location.pathname));
 ```
 
 ### useSearchParams


### PR DESCRIPTION
One of the code blocks in README had invalid syntax.