### PR TITLE
Fix #96 - support replace with hashIntegration

### DIFF
--- a/src/integration.ts
+++ b/src/integration.ts
@@ -110,12 +110,12 @@ export function hashIntegration() {
   return createIntegration(
     () => window.location.hash.slice(1),
     ({ value, replace, scroll, state }) => {
-      const hashIndex = value.indexOf("#");
       if (replace) {
-        window.history.replaceState(state, "", (hashIndex === 0 ? "" : "#") + value);
+        window.history.replaceState(state, "", "#" + value);
       } else {
         window.location.hash = value;
       }
+      const hashIndex = value.indexOf("#");
       const hash = hashIndex >= 0 ? value.slice(hashIndex + 1) : "";
       scrollToHash(hash, scroll);
     },

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -109,9 +109,13 @@ export function pathIntegration() {
 export function hashIntegration() {
   return createIntegration(
     () => window.location.hash.slice(1),
-    ({ value, scroll }) => {
-      window.location.hash = value;
+    ({ value, replace, scroll, state }) => {
       const hashIndex = value.indexOf("#");
+      if (replace) {
+        window.history.replaceState(state, "", (hashIndex === 0 ? "" : "#") + value);
+      } else {
+        window.location.hash = value;
+      }
       const hash = hashIndex >= 0 ? value.slice(hashIndex + 1) : "";
       scrollToHash(hash, scroll);
     },


### PR DESCRIPTION
Not 100% sure if the `(hashIndex === 0 ? "" : "#")` check is required or if we can always simply always prepend '#'.  When testing here `value` never had the leading '#' - but others may use differently?