### PR TITLE
fix typings in Route

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -168,7 +168,7 @@ export const Route = (props: RouteProps) => {
     get children() {
       return childRoutes();
     }
-  });
+  }) as unknown as JSX.Element;
 }
 
 export const Outlet = () => {


### PR DESCRIPTION
A recent [commit](https://github.com/solidjs/solid-app-router/commit/9b3348558465058f6d0a7a1740076c1ecd622ed8) broke the typings because of removed `as unknown as JSX.Element` cast.