### PR TITLE
Readme example typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import { Routes, Route } from "solid-app-router"
 
 export default function App() {
   return (<>
-    <h1>My Site with Lots of Pages<h1/>
+    <h1>My Site with Lots of Pages</h1>
     <Routes>
 
     </Routes>


### PR DESCRIPTION
Fixes closing tag in readme example. self closing ```<h1/>``` in "Configure Your Routes" example causes a 

```JSX fragment has no corresponding closing tag.ts(17014)```