### PR TITLE
Allow passing path as array in Route component

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -147,7 +147,7 @@ export const useRoutes = (routes: RouteDefinition | RouteDefinition[], base?: st
 };
 
 export type RouteProps = {
-  path: string;
+  path: string | string[];
   children?: JSX.Element;
   data?: RouteDataFunc;
 } & (


### PR DESCRIPTION
Looks like an (intentional?) omission in:
https://github.com/solidjs/solid-app-router/commit/456da636446ec57562dc8f5ed4f3fea46cf8e5f2