### PR TITLE
Update useRouteData return type annotation

### DIFF
--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,4 +1,19 @@
-import { Accessor, Component, JSX, createResource } from "solid-js";
+import type { Component, JSX, Accessor } from "solid-js";
+import {
+  createComponent,
+  createContext,
+  createMemo,
+  createRenderEffect,
+  createSignal,
+  on,
+  onCleanup,
+  untrack,
+  useContext,
+  useTransition,
+  resetErrorBoundaries
+} from "solid-js";
+import { isServer } from "solid-js/web";
+import { normalizeIntegration } from "./integration";
 import type {
   Branch,
   Location,
@@ -18,33 +33,17 @@ import type {
   SetParams
 } from "./types";
 import {
-  createComponent,
-  createContext,
-  createMemo,
-  createRenderEffect,
-  createSignal,
-  on,
-  onCleanup,
-  resetErrorBoundaries,
-  untrack,
-  useContext,
-  useTransition
-} from "solid-js";
-import {
-  createMatcher,
   createMemoObject,
-  expandOptionals,
   extractSearchParams,
   invariant,
-  joinPaths,
-  mergeSearchString,
   resolvePath,
+  createMatcher,
+  joinPaths,
   scoreRoute,
-  urlDecode
+  mergeSearchString,
+  urlDecode,
+  expandOptionals
 } from "./utils";
-
-import { isServer } from "solid-js/web";
-import { normalizeIntegration } from "./integration";
 
 const MAX_REDIRECTS = 100;
 

--- a/src/routing.ts
+++ b/src/routing.ts
@@ -1,19 +1,4 @@
-import type { Component, JSX, Accessor } from "solid-js";
-import {
-  createComponent,
-  createContext,
-  createMemo,
-  createRenderEffect,
-  createSignal,
-  on,
-  onCleanup,
-  untrack,
-  useContext,
-  useTransition,
-  resetErrorBoundaries
-} from "solid-js";
-import { isServer } from "solid-js/web";
-import { normalizeIntegration } from "./integration";
+import { Accessor, Component, JSX, createResource } from "solid-js";
 import type {
   Branch,
   Location,
@@ -33,17 +18,33 @@ import type {
   SetParams
 } from "./types";
 import {
+  createComponent,
+  createContext,
+  createMemo,
+  createRenderEffect,
+  createSignal,
+  on,
+  onCleanup,
+  resetErrorBoundaries,
+  untrack,
+  useContext,
+  useTransition
+} from "solid-js";
+import {
+  createMatcher,
   createMemoObject,
+  expandOptionals,
   extractSearchParams,
   invariant,
-  resolvePath,
-  createMatcher,
   joinPaths,
-  scoreRoute,
   mergeSearchString,
-  urlDecode,
-  expandOptionals
+  resolvePath,
+  scoreRoute,
+  urlDecode
 } from "./utils";
+
+import { isServer } from "solid-js/web";
+import { normalizeIntegration } from "./integration";
 
 const MAX_REDIRECTS = 100;
 
@@ -85,7 +86,8 @@ export const useMatch = (path: () => string) => {
 
 export const useParams = <T extends Params>() => useRoute().params as T;
 
-export const useRouteData = <T>() => useRoute().data as T;
+type MaybeReturnType<T> = T extends (...args: any) => infer R ? R : T;
+export const useRouteData = <T>() => useRoute().data as MaybeReturnType<T>;
 
 export const useSearchParams = <T extends Params>(): [
   T,


### PR DESCRIPTION
Saw this on stream.

It was mentioned that the ergonomics of having to use the built-in `ReturnType` type when calling `useRouteData` could be improved. Maybe something like this could be useful?

With this change you can just pass `typeof myFunc`:

```ts
function userData() {
  const [user] = createResource(async () => ({ id: 123, name: "hello" }));
  return user;
}

const user = useRouteData<typeof userData>();
//    ^? {id: number, name: string} | undefined
```

while still supporting the old type annotation, i.e.:

```ts
const user = useRouteData<ReturnType<typeof userData>>();
//    ^? {id: number, name: string} | undefined
```

Of course, if this isn't desirable or there are plans for something else, feel free to disregard/close. Great work either way! :)