### PR TITLE
Merge `classList` props on NavLink

### DIFF
--- a/src/components.tsx
+++ b/src/components.tsx
@@ -233,7 +233,7 @@ export function NavLink(props: NavLinkProps) {
     <LinkBase
       {...rest}
       to={to()}
-      classList={{ [props.inactiveClass!]: !isActive(), [props.activeClass!]: isActive() }}
+      classList={{ [props.inactiveClass!]: !isActive(), [props.activeClass!]: isActive(), ...rest.classList }}
       aria-current={isActive() ? "page" : undefined}
     />
   );


### PR DESCRIPTION
This PR adds support for the `classList` prop on the `NavLink` Component.

Before this PR, this pattern would be problematic:

```tsx
<NavLink classList={{ [myClass]: true }} />
```

The NavLink would just entirely void the prop and overwrite it with its internal classes, leading to confusion.